### PR TITLE
Automatic CI/CD for Sonar and Render with Github Actions

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 15
     name: Build and Test
     runs-on: ubuntu-latest
 
@@ -19,13 +20,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          cache: 'gradle'
+          cache-dependency-path: |
+            football-stats-predictions/gradle/wrapper/gradle-wrapper.properties
+            football-stats-predictions/build.gradle.kts
 
       - name: Grant execute permission for gradlew
         working-directory: ./football-stats-predictions
@@ -42,6 +40,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/automatic-ci-cd'
+    environment:
+      name: production
+      url: ${{ vars.RENDER_APP_URL }}
 
     steps:
       - name: Trigger Deploy in Render

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -1,0 +1,48 @@
+name: Render CI/CD
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Grant execute permission for gradlew
+        working-directory: ./football-stats-predictions
+        run: chmod +x gradlew
+
+      - name: Build and Test
+        working-directory: ./football-stats-predictions
+        env:
+          FOOTBALL_API_KEY: ${{ secrets.FOOTBALL_API_KEY }}
+        run: ./gradlew build --no-daemon --parallel --console=plain --build-cache
+
+  deploy:
+    name: Deploy to Render
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/automatic-ci-cd'
+
+    steps:
+      - name: Trigger Deploy in Render
+        run: curl -X POST ${{ secrets.RENDER_DEPLOY_HOOK }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -46,4 +46,17 @@ jobs:
 
     steps:
       - name: Trigger Deploy in Render
-        run: curl -X POST ${{ secrets.RENDER_DEPLOY_HOOK }}
+        run: |
+          echo "::group::Starting Render Deploy..."
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X POST ${{ secrets.RENDER_DEPLOY_HOOK }})
+          HTTP_STATUS=$(echo "$RESPONSE" | tail -n1)
+          BODY=$(echo "$RESPONSE" | head -n1)
+          
+          if [ "$HTTP_STATUS" -eq 200 ]; then
+            echo -e "\033[32mDeployment success!\033[0m"
+          else
+            echo -e "\033[31mDeployment failed: HTTP Status $HTTP_STATUS\033[0m"
+            echo -e "\033[31mResponse: $BODY\033[0m"
+            exit 1
+          fi
+          echo "::endgroup::"

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -41,7 +41,7 @@ jobs:
     name: Deploy to Render
     needs: build
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/automatic-ci-cd'
+    if: github.ref == 'refs/heads/main'
     environment:
       name: production
       url: ${{ vars.RENDER_APP_URL }}

--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - '**'
+    paths-ignore:
+      - '*.md'
 
 jobs:
   build:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: 'zulu' # Alternative distribution options are available
+          distribution: 'zulu'
 
       - name: Cache SonarQube packages
         uses: actions/cache@v4

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: 'zulu'
+          distribution: 'temurin'
 
       - name: Cache SonarQube packages
         uses: actions/cache@v4

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -3,8 +3,12 @@ on:
   push:
     branches:
       - '**'
+    paths-ignore:
+      - '*.md'
   pull_request:
     types: [ opened, synchronize, reopened ]
+    paths-ignore:
+      - '*.md'
 
 jobs:
   build:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -2,13 +2,19 @@ name: SonarQube
 on:
   push:
     branches:
-      - main
+      - '**'
   pull_request:
     types: [ opened, synchronize, reopened ]
+
 jobs:
   build:
+    # avoids duplicate analysis on open PRs and PRs from forks
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 15
     name: Build and analyze
     runs-on: ubuntu-latest
+    environment:
+      name: production
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,6 +25,10 @@ jobs:
         with:
           java-version: 17
           distribution: 'temurin'
+          cache: 'gradle'
+          cache-dependency-path: |
+            football-stats-predictions/gradle/wrapper/gradle-wrapper.properties
+            football-stats-predictions/build.gradle.kts
 
       - name: Cache SonarQube packages
         uses: actions/cache@v4
@@ -26,13 +36,6 @@ jobs:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
 
       - name: Grant execute permission for gradlew
         working-directory: ./football-stats-predictions
@@ -43,4 +46,4 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           FOOTBALL_API_KEY: ${{ secrets.FOOTBALL_API_KEY }}
-        run: ./gradlew build sonar --info
+        run: ./gradlew build sonar --no-daemon --parallel --info

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 - Modelo segun necesidad de enpoints ✅
 - Testing automático unitario según las pautas de la materia ✅
 
- 
 **Funcionalidad**
 
 - Creacion de usuario y ApiKEY para acceder al resto de los endpoints ❌

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - [SonarCloud](https://sonarcloud.io/project/overview?id=luchist_unq-dapps-202501-grupo-g)
 - [Render](https://unq-dapps-202501-grupo-g.onrender.com)
 
-### Entrega Nro. 1
+## Entrega Nro. 1
 
 **Core**
 
@@ -15,7 +15,7 @@
 - Configuración en GitHubActions ✅
 - Build corriendo y SUCCESS ✅
 - SonarCloud (Registrar el proyecto y con issues menor a 10) ✅
-- Deploy automático en Render usando Git Actions de GitHub ❌
+- Deploy automático en Render usando Git Actions de GitHub ✅
 - Clean Code según la materia (todo en Ingles) ✅
 - JWT implementado ❌
 - Configuracion de https://swagger.io/ en el back-API  (v3) ✅
@@ -29,3 +29,10 @@
 
 - Creacion de usuario y ApiKEY para acceder al resto de los endpoints ❌
 - Endpoint de jugadores de un equipo ✅
+
+## Integrantes
+
+|              |                                                                                                                                              |           
+|--------------|:--------------------------------------------------------------------------------------------------------------------------------------------:|
+| Luis Coronel |       [![GitHub followers](https://img.shields.io/github/followers/luchist.svg?style=social&label=Follow)](https://github.com/luchist)       |
+| Ulises Lopez | [![GitHub followers](https://img.shields.io/github/followers/uliseslopez98.svg?style=social&label=Follow)](https://github.com/uliseslopez98) |


### PR DESCRIPTION
**General**
- Renamed each .yml for clarity
- Optimized Gradle cache and gradlew parameters for faster builds
- Switched to Java 17 Temurin for consistency with Dockerfile
- **Both pipelines will not trigger on changes in .md files**
- Updated README.md with new status
- Added _production_ **github environment** with render url

**Render**
- **Builds** for every branch but will only **deploy** on changes in '**main**' branch
- Added error handling for '_Trigger Deploy in Render_' task with GitHub console colors

**Sonar**
- Avoids duplicated scans for open Pull Requests and PRs from forks
- Triggers for **every branch** (not available on Sonar dashboard on the free plan, but available on the GitHub console)