### PR TITLE
Add scheduled matches endpoint

### DIFF
--- a/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPI.kt
+++ b/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPI.kt
@@ -53,7 +53,7 @@ class FootballDataAPI(
     }
 
     fun getScheduledMatches(teamName: String): List<Match> {
-        val requestURL = apiUrl + "v4/teams/$teamName/matches?status=SCHEDULED"
+        val requestURL = "v4/teams/$teamName/matches?status=SCHEDULED"
         val response = makeApiRequest(requestURL)
 
         return mapper.parseScheduledMatches(response)

--- a/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPI.kt
+++ b/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPI.kt
@@ -1,12 +1,16 @@
 package com.footballdata.football_stats_predictions.data
 
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.footballdata.football_stats_predictions.model.Match
 import com.footballdata.football_stats_predictions.model.Player
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.net.HttpURLConnection
 import java.net.URL
+import java.text.SimpleDateFormat
 
 
 @Component
@@ -18,62 +22,95 @@ class FootballDataAPI(
     }
 ) {
 
-    fun getTeamComposition(teamName: String): List<Player> {
+    private val mapper: ObjectMapper = ObjectMapper()
 
-        val requestURL = apiUrl + "v4/teams/$teamName/"
+    init {
+        // Mapper configuration
+        // Adds support for nullable types, data classes, kotlin specific types
+        mapper.findAndRegisterModules()
+        // Disable failure on unknown properties to avoid issues with API changes for resilience
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        // Accepts single values as arrays
+        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+        // Avoids failure on null values for primitive types, for numeric types that may be null
+        mapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+        // Avoids failure on unknown enum values
+        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
+        // Consistent date format for serialization
+        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+        // Date format for parsing date strings
+        mapper.dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+    }
 
+    private fun buildUrl(endpoint: String): String {
+        val baseUrl = apiUrl.removeSuffix("/")
+        val cleanEndpoint = endpoint.removePrefix("/")
+        return "$baseUrl/$cleanEndpoint"
+    }
+
+    private fun makeApiRequest(endpoint: String): String {
+        val requestURL = buildUrl(endpoint)
         val connection = connectionFactory(requestURL)
 
-        connection.apply {
-            requestMethod = "GET"
-            setRequestProperty("Accept", "application/json")
-            setRequestProperty("X-Auth-Token", apiKey)
-        }
+        return try {
+            connection.apply {
+                requestMethod = "GET"
+                setRequestProperty("Accept", "application/json")
+                setRequestProperty("X-Auth-Token", apiKey)
+            }
 
-        val response = connection.inputStream.bufferedReader().use { it.readText() }
-        val mapper = ObjectMapper()
+            if (connection.responseCode != HttpURLConnection.HTTP_OK) {
+                throw RuntimeException("API request failed: ${connection.responseCode}")
+            }
+
+            connection.inputStream.bufferedReader().use { it.readText() }
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private fun parsePlayer(playerNode: JsonNode) = Player(
+        id = playerNode.get("id").asLong(),
+        playerName = playerNode.get("name").asText(),
+        position = playerNode.get("position").asText(),
+        dateOfBirth = playerNode.get("dateOfBirth").asText(),
+        nationality = playerNode.get("nationality").asText(),
+        shoots = 0,
+        interceptions = 0
+    )
+
+    private fun parseMatch(matchNode: JsonNode) = Match(
+        id = matchNode.get("id").asLong(),
+        date = matchNode.get("utcDate").asText(),
+        league = matchNode.get("competition").get("name").asText(),
+        homeTeamId = matchNode.get("homeTeam").get("id").asLong(),
+        homeTeamName = matchNode.get("homeTeam").get("name").asText(),
+        awayTeamId = matchNode.get("awayTeam").get("id").asLong(),
+        awayTeamName = matchNode.get("awayTeam").get("name").asText()
+    )
+
+    fun getTeamComposition(teamName: String): List<Player> {
+
+        val requestURL = "v4/teams/$teamName/"
+
+        val response = makeApiRequest(requestURL)
         val rootNode = mapper.readTree(response)
         val squadNode = rootNode.get("squad")
 
         return squadNode.map { playerNode ->
-            Player(
-                id = playerNode.get("id").asLong(),
-                playerName = playerNode.get("name").asText(),
-                position = playerNode.get("position").asText(),
-                dateOfBirth = playerNode.get("dateOfBirth").asText(),
-                nationality = playerNode.get("nationality").asText(),
-                shoots = 0,
-                interceptions = 0
-            )
+            parsePlayer(playerNode)
         }
     }
 
     fun getScheduledMatches(teamName: String): List<Match> {
         val requestURL = apiUrl + "v4/teams/$teamName/matches?status=SCHEDULED"
 
-        val connection = connectionFactory(requestURL)
-
-        connection.apply {
-            requestMethod = "GET"
-            setRequestProperty("Accept", "application/json")
-            setRequestProperty("X-Auth-Token", apiKey)
-        }
-
-        val response = connection.inputStream.bufferedReader().use { it.readText() }
-        val mapper = ObjectMapper()
+        val response = makeApiRequest(requestURL)
         val rootNode = mapper.readTree(response)
         val matchesNode = rootNode.get("matches")
 
         return matchesNode.map { matchNode ->
-            Match(
-                id = matchNode.get("id").asLong(),
-                date = matchNode.get("utcDate").asText(),
-                league = matchNode.get("competition").get("name").asText(),
-                homeTeamId = matchNode.get("homeTeam").get("id").asLong(),
-                homeTeamName = matchNode.get("homeTeam").get("name").asText(),
-                awayTeamId = matchNode.get("awayTeam").get("id").asLong(),
-                awayTeamName = matchNode.get("awayTeam").get("name").asText()
-            )
+            parseMatch(matchNode)
         }
     }
 }

--- a/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPI.kt
+++ b/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPI.kt
@@ -1,46 +1,22 @@
 package com.footballdata.football_stats_predictions.data
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
 import com.footballdata.football_stats_predictions.model.Match
 import com.footballdata.football_stats_predictions.model.Player
+import com.footballdata.football_stats_predictions.utils.JsonMapper
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.net.HttpURLConnection
 import java.net.URL
-import java.text.SimpleDateFormat
-
 
 @Component
 class FootballDataAPI(
     @Value("\${integration.football.api.url}") val apiUrl: String,
     @Value("\${integration.football.api.apikey}") val apiKey: String,
+    private val mapper: JsonMapper = JsonMapper(),
     val connectionFactory: (String) -> HttpURLConnection = { urlString: String ->
         URL(urlString).openConnection() as HttpURLConnection
     }
 ) {
-
-    private val mapper: ObjectMapper = ObjectMapper()
-
-    init {
-        // Mapper configuration
-        // Adds support for nullable types, data classes, kotlin specific types
-        mapper.findAndRegisterModules()
-        // Disable failure on unknown properties to avoid issues with API changes for resilience
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        // Accepts single values as arrays
-        mapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
-        // Avoids failure on null values for primitive types, for numeric types that may be null
-        mapper.configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
-        // Avoids failure on unknown enum values
-        mapper.configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
-        // Consistent date format for serialization
-        mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
-        // Date format for parsing date strings
-        mapper.dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
-    }
 
     private fun buildUrl(endpoint: String): String {
         val baseUrl = apiUrl.removeSuffix("/")
@@ -69,48 +45,17 @@ class FootballDataAPI(
         }
     }
 
-    private fun parsePlayer(playerNode: JsonNode) = Player(
-        id = playerNode.get("id").asLong(),
-        playerName = playerNode.get("name").asText(),
-        position = playerNode.get("position").asText(),
-        dateOfBirth = playerNode.get("dateOfBirth").asText(),
-        nationality = playerNode.get("nationality").asText(),
-        shoots = 0,
-        interceptions = 0
-    )
-
-    private fun parseMatch(matchNode: JsonNode) = Match(
-        id = matchNode.get("id").asLong(),
-        date = matchNode.get("utcDate").asText(),
-        league = matchNode.get("competition").get("name").asText(),
-        homeTeamId = matchNode.get("homeTeam").get("id").asLong(),
-        homeTeamName = matchNode.get("homeTeam").get("name").asText(),
-        awayTeamId = matchNode.get("awayTeam").get("id").asLong(),
-        awayTeamName = matchNode.get("awayTeam").get("name").asText()
-    )
-
     fun getTeamComposition(teamName: String): List<Player> {
-
         val requestURL = "v4/teams/$teamName/"
-
         val response = makeApiRequest(requestURL)
-        val rootNode = mapper.readTree(response)
-        val squadNode = rootNode.get("squad")
 
-        return squadNode.map { playerNode ->
-            parsePlayer(playerNode)
-        }
+        return mapper.parseTeamComposition(response)
     }
 
     fun getScheduledMatches(teamName: String): List<Match> {
         val requestURL = apiUrl + "v4/teams/$teamName/matches?status=SCHEDULED"
-
         val response = makeApiRequest(requestURL)
-        val rootNode = mapper.readTree(response)
-        val matchesNode = rootNode.get("matches")
 
-        return matchesNode.map { matchNode ->
-            parseMatch(matchNode)
-        }
+        return mapper.parseScheduledMatches(response)
     }
 }

--- a/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPI.kt
+++ b/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPI.kt
@@ -16,31 +16,7 @@ class FootballDataAPI(
     val connectionFactory: (String) -> HttpURLConnection = { urlString: String ->
         URL(urlString).openConnection() as HttpURLConnection
     }
-) : StatisticsProvider {
-
-    override fun getTeamStatistics(teamName: String): TeamStatistics {
-        TODO("Not yet implemented")
-    }
-
-    override fun getPlayerStatistics(playerName: String): PlayerStatistics {
-        TODO("Not yet implemented")
-    }
-
-    override fun getMatchStatistics(matchId: String): MatchStatistics {
-        TODO("Not yet implemented")
-    }
-
-    fun getMatchResult(matchDate: String, leagueName: String) {
-        TODO("Not yet implemented")
-    }
-
-    fun getFixtureLeague(leagueName: String) {
-        TODO("Not yet implemented")
-    }
-
-    fun getTeamSetup(teamName: String, matchDate: String, leagueName: String) {
-        TODO("Not yet implemented")
-    }
+) {
 
     fun getTeamComposition(teamName: String): List<Player> {
 

--- a/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/model/Match.kt
+++ b/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/model/Match.kt
@@ -1,10 +1,23 @@
 package com.footballdata.football_stats_predictions.model
 
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+
 class Match(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
     val league: String,
     val date: String,
-    var homeTeam: Team,
-    var awayTeam: Team
+    val homeTeamId: Long,
+    val homeTeamName: String,
+    val awayTeamId: Long,
+    val awayTeamName: String,
+    @Transient
+    var homeTeam: Team? = null,
+    @Transient
+    var awayTeam: Team? = null
 ) {
     fun generateMatchPrediction() {
         throw NotImplementedError()

--- a/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/service/TeamService.kt
+++ b/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/service/TeamService.kt
@@ -1,6 +1,7 @@
 package com.footballdata.football_stats_predictions.service
 
 import com.footballdata.football_stats_predictions.data.FootballDataAPI
+import com.footballdata.football_stats_predictions.model.Match
 import com.footballdata.football_stats_predictions.model.Player
 import com.footballdata.football_stats_predictions.model.TeamBuilder
 import com.footballdata.football_stats_predictions.repositories.PlayerRepository
@@ -46,5 +47,9 @@ class TeamService(
 
         // return the team composition
         return teamComposition
+    }
+
+    fun getScheduledMatches(teamName: String): List<Match> {
+        return footballDataAPI.getScheduledMatches(teamName)
     }
 }

--- a/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/utils/JsonMapper.kt
+++ b/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/utils/JsonMapper.kt
@@ -1,0 +1,62 @@
+package com.footballdata.football_stats_predictions.utils
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.footballdata.football_stats_predictions.model.Match
+import com.footballdata.football_stats_predictions.model.Player
+import java.text.SimpleDateFormat
+
+//@Component
+class JsonMapper {
+    // Mapper configuration
+    private val mapper: ObjectMapper = ObjectMapper().apply {
+        // Adds support for nullable types, data classes, kotlin specific types
+        findAndRegisterModules()
+        // Disable failure on unknown properties to avoid issues with API changes for resilience
+        configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        // Accepts single values as arrays
+        configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true)
+        // Avoids failure on null values for primitive types, for numeric types that may be null
+        configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+        // Avoids failure on unknown enum values
+        configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
+        // Consistent date format for serialization
+        configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+        // Date format for parsing date strings
+        dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'")
+    }
+
+    private fun parsePlayer(playerNode: JsonNode) = Player(
+        id = playerNode.get("id").asLong(),
+        playerName = playerNode.get("name").asText(),
+        position = playerNode.get("position").asText(),
+        dateOfBirth = playerNode.get("dateOfBirth").asText(),
+        nationality = playerNode.get("nationality").asText(),
+        shoots = 0,
+        interceptions = 0
+    )
+
+    private fun parseMatch(matchNode: JsonNode) = Match(
+        id = matchNode.get("id").asLong(),
+        date = matchNode.get("utcDate").asText(),
+        league = matchNode.get("competition").get("name").asText(),
+        homeTeamId = matchNode.get("homeTeam").get("id").asLong(),
+        homeTeamName = matchNode.get("homeTeam").get("name").asText(),
+        awayTeamId = matchNode.get("awayTeam").get("id").asLong(),
+        awayTeamName = matchNode.get("awayTeam").get("name").asText()
+    )
+
+    fun parseTeamComposition(json: String): List<Player> {
+        val rootNode = mapper.readTree(json)
+        val squadNode = rootNode.get("squad")
+        return squadNode.map { parsePlayer(it) }
+    }
+
+    fun parseScheduledMatches(json: String): List<Match> {
+        val rootNode = mapper.readTree(json)
+        val matchesNode = rootNode.get("matches")
+        return matchesNode.map { parseMatch(it) }
+    }
+}

--- a/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/webservice/TeamController.kt
+++ b/football-stats-predictions/src/main/kotlin/com/footballdata/football_stats_predictions/webservice/TeamController.kt
@@ -1,5 +1,6 @@
 package com.footballdata.football_stats_predictions.webservice
 
+import com.footballdata.football_stats_predictions.model.Match
 import com.footballdata.football_stats_predictions.model.Player
 import com.footballdata.football_stats_predictions.service.TeamService
 import io.swagger.v3.oas.annotations.Operation
@@ -24,5 +25,17 @@ class TeamController(@field:Autowired var teamService: TeamService) {
         @PathVariable teamName: String
     ): List<Player> {
         return teamService.getTeamComposition(teamName)
+    }
+
+    @Operation(summary = "Get scheduled matches", description = "Returns a list of scheduled Matches for a team")
+    @GetMapping("/{teamName}/matches")
+    fun getScheduledMatches(
+        @Parameter(
+            description = "The team name for which scheduled matches are needed",
+            required = true
+        )
+        @PathVariable teamName: String
+    ): List<Match> {
+        return teamService.getScheduledMatches(teamName)
     }
 }

--- a/football-stats-predictions/src/test/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPITest.kt
+++ b/football-stats-predictions/src/test/kotlin/com/footballdata/football_stats_predictions/data/FootballDataAPITest.kt
@@ -87,4 +87,133 @@ class FootballDataAPITest {
             footballDataAPI.getTeamComposition("90")
         }
     }
+
+    @Test
+    fun `should parse scheduled matches correctly when API returns valid data`() {
+        // Arrange
+        val mockJson = """
+    {
+        "matches": [
+            {
+                "area": {
+                    "id": 2072,
+                    "name": "England",
+                    "code": "ENG",
+                    "flag": "https://crests.football-data.org/770.svg"
+                },
+                "competition": {
+                    "id": 2021,
+                    "name": "Premier League",
+                    "code": "PL",
+                    "type": "LEAGUE",
+                    "emblem": "https://crests.football-data.org/PL.png"
+                },
+                "season": {
+                    "id": 2287,
+                    "startDate": "2024-08-16",
+                    "endDate": "2025-05-25",
+                    "currentMatchday": 38,
+                    "winner": null
+                },
+                "id": 497781,
+                "utcDate": "2025-07-25T15:00:00Z",
+                "status": "TIMED",
+                "matchday": 38,
+                "stage": "REGULAR_SEASON",
+                "group": null,
+                "lastUpdated": "2025-05-25T00:20:40Z",
+                "homeTeam": {
+                    "id": 63,
+                    "name": "Fulham FC",
+                    "shortName": "Fulham",
+                    "tla": "FUL",
+                    "crest": "https://crests.football-data.org/63.png"
+                },
+                "awayTeam": {
+                    "id": 65,
+                    "name": "Manchester City FC",
+                    "shortName": "Man City",
+                    "tla": "MCI",
+                    "crest": "https://crests.football-data.org/65.png"
+                },
+                "score": {
+                    "winner": null,
+                    "duration": "REGULAR",
+                    "fullTime": {
+                        "home": null,
+                        "away": null
+                    },
+                    "halfTime": {
+                        "home": null,
+                        "away": null
+                    }
+                }
+            },
+            {
+                "id": 497789,
+                "utcDate": "2026-09-25T15:00:00Z",
+                "status": "SCHEDULED",
+                "competition": {
+                    "name": "Champions League"
+                },
+                "homeTeam": {
+                    "id": 86,
+                    "name": "Real Madrid"
+                },
+                "awayTeam": {
+                    "id": 65,
+                    "name": "Manchester City"
+                }
+            }
+        ]
+    }
+    """.trimIndent()
+
+        `when`(connection.inputStream).thenReturn(ByteArrayInputStream(mockJson.toByteArray()))
+        `when`(connection.responseCode).thenReturn(200)
+
+        // Act
+        val result = footballDataAPI.getScheduledMatches("65")
+
+        // Assert
+        assertEquals(2, result.size)
+        with(result[0]) {
+            assertEquals(497781L, id)
+            assertEquals("2025-07-25T15:00:00Z", date)
+            assertEquals("Premier League", league)
+            assertEquals("Fulham FC", homeTeamName)
+            assertEquals("Manchester City FC", awayTeamName)
+        }
+        with(result[1]) {
+            assertEquals(497789L, id)
+            assertEquals("2026-09-25T15:00:00Z", date)
+            assertEquals("Champions League", league)
+            assertEquals("Real Madrid", homeTeamName)
+            assertEquals("Manchester City", awayTeamName)
+        }
+    }
+
+    @Test
+    fun `should throw exception when API returns error response for scheduled matches`() {
+        // Arrange
+        `when`(connection.responseCode).thenReturn(404)
+
+        // Act & Assert
+        assertThrows<Exception> {
+            footballDataAPI.getScheduledMatches("invalid-team")
+        }
+    }
+
+    @Test
+    fun `should throw exception when API returns invalid JSON for scheduled matches`() {
+        // Arrange
+        val invalidJson = "{ invalid json }"
+        `when`(connection.inputStream).thenReturn(ByteArrayInputStream(invalidJson.toByteArray()))
+        `when`(connection.responseCode).thenReturn(200)
+
+        // Act & Assert
+        assertThrows<Exception> {
+            footballDataAPI.getScheduledMatches("86")
+        }
+    }
 }

--- a/football-stats-predictions/src/test/kotlin/com/footballdata/football_stats_predictions/utils/JsonMapperTest.kt
+++ b/football-stats-predictions/src/test/kotlin/com/footballdata/football_stats_predictions/utils/JsonMapperTest.kt
@@ -1,0 +1,93 @@
+package com.footballdata.football_stats_predictions.utils
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class JsonMapperTest {
+    private val jsonMapper = JsonMapper()
+
+    @Test
+    fun `should parse player correctly with all fields`() {
+        val json = """
+        {
+            "squad": [{
+                "id": 1,
+                "name": "Lionel Messi",
+                "position": "Forward",
+                "dateOfBirth": "1987-06-24",
+                "nationality": "Argentina"
+            }]
+        }
+        """.trimIndent()
+
+        val result = jsonMapper.parseTeamComposition(json)
+
+        assertEquals(1, result.size)
+        with(result[0]) {
+            assertEquals(1L, id)
+            assertEquals("Lionel Messi", playerName)
+            assertEquals("Forward", position)
+            assertEquals("1987-06-24", dateOfBirth)
+            assertEquals("Argentina", nationality)
+        }
+    }
+
+    @Test
+    fun `should parse match with minimum required fields`() {
+        val json = """
+        {
+            "matches": [{
+                "id": 1,
+                "utcDate": "2024-03-20T20:00:00Z",
+                "competition": { "name": "La Liga" },
+                "homeTeam": { "id": 81, "name": "Barcelona" },
+                "awayTeam": { "id": 86, "name": "Real Madrid" }
+            }]
+        }
+        """.trimIndent()
+
+        val result = jsonMapper.parseScheduledMatches(json)
+
+        assertEquals(1, result.size)
+        with(result[0]) {
+            assertEquals(1L, id)
+            assertEquals("2024-03-20T20:00:00Z", date)
+            assertEquals("La Liga", league)
+            assertEquals(81L, homeTeamId)
+            assertEquals("Barcelona", homeTeamName)
+            assertEquals(86L, awayTeamId)
+            assertEquals("Real Madrid", awayTeamName)
+        }
+    }
+
+    @Test
+    fun `should handle empty team composition`() {
+        val json = """{ "squad": [] }"""
+        val result = jsonMapper.parseTeamComposition(json)
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `should handle malformed JSON for team composition`() {
+        val invalidJson = "{ invalid json }"
+        assertThrows<Exception> {
+            jsonMapper.parseTeamComposition(invalidJson)
+        }
+    }
+
+    @Test
+    fun `should handle empty scheduled matches`() {
+        val json = """{ "matches": [] }"""
+        val result = jsonMapper.parseScheduledMatches(json)
+        assertEquals(0, result.size)
+    }
+
+    @Test
+    fun `should handle malformed JSON for scheduled matches`() {
+        val invalidJson = "{ invalid json }"
+        assertThrows<Exception> {
+            jsonMapper.parseScheduledMatches(invalidJson)
+        }
+    }
+}

--- a/football-stats-predictions/src/test/kotlin/com/footballdata/football_stats_predictions/webservice/TeamControllerTest.kt
+++ b/football-stats-predictions/src/test/kotlin/com/footballdata/football_stats_predictions/webservice/TeamControllerTest.kt
@@ -1,0 +1,102 @@
+package com.footballdata.football_stats_predictions.webservice
+
+import com.footballdata.football_stats_predictions.model.Match
+import com.footballdata.football_stats_predictions.model.Player
+import com.footballdata.football_stats_predictions.service.TeamService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+import org.mockito.junit.jupiter.MockitoExtension
+
+@ExtendWith(MockitoExtension::class)
+class TeamControllerTest {
+
+    @Mock
+    private lateinit var teamService: TeamService
+
+    @InjectMocks
+    private lateinit var teamController: TeamController
+
+    @Test
+    fun `getTeamComposition should return list of players`() {
+        // Arrange
+        val teamName = "Barcelona"
+        val expectedPlayers = listOf(
+            Player(
+                1L, "Lionel Messi", "Forward",
+                "1987-06-24", "Argentina", 10, 10
+            ),
+            Player(
+                2L, "Pedri", "Midfielder",
+                "2002-11-25", "Spain", 5, 5
+            ),
+        )
+        `when`(teamService.getTeamComposition(teamName)).thenReturn(expectedPlayers)
+
+        // Act
+        val result = teamController.getTeamComposition(teamName)
+
+        // Assert
+        assertEquals(expectedPlayers, result)
+        verify(teamService).getTeamComposition(teamName)
+    }
+
+    @Test
+    fun `getTeamComposition should propagate exception when service fails`() {
+        // Arrange
+        val teamName = "Barcelona"
+        `when`(teamService.getTeamComposition(teamName))
+            .thenThrow(RuntimeException("Service error"))
+
+        // Act & Assert
+        assertThrows<RuntimeException> {
+            teamController.getTeamComposition(teamName)
+        }
+        verify(teamService).getTeamComposition(teamName)
+    }
+
+    @Test
+    fun `getScheduledMatches should return list of matches`() {
+        // Arrange
+        val teamName = "Barcelona"
+        val expectedMatches = listOf(
+            Match(
+                id = 1,
+                league = "La Liga",
+                date = "2024-03-20T20:00:00Z",
+                homeTeamId = 81,
+                homeTeamName = "Barcelona",
+                awayTeamId = 86,
+                awayTeamName = "Real Madrid"
+            )
+        )
+        `when`(teamService.getScheduledMatches(teamName)).thenReturn(expectedMatches)
+
+        // Act
+        val result = teamController.getScheduledMatches(teamName)
+
+        // Assert
+        assertEquals(expectedMatches, result)
+        verify(teamService).getScheduledMatches(teamName)
+    }
+
+    @Test
+    fun `getScheduledMatches should handle empty list`() {
+        // Arrange
+        val teamName = "Barcelona"
+        val expectedMatches = emptyList<Match>()
+        `when`(teamService.getScheduledMatches(teamName)).thenReturn(expectedMatches)
+
+        // Act
+        val result = teamController.getScheduledMatches(teamName)
+
+        // Assert
+        assertEquals(expectedMatches, result)
+        verify(teamService).getScheduledMatches(teamName)
+    }
+}


### PR DESCRIPTION
- added endpoint to get scheduled matches for a team
- separated a JsonMapper class from the main FootballDataAPI class
- deleted unused methods and simplified FootballDataAPI class
- Match class now stores team id and name, not the full Team class
- added unit tests for controllers
- added unit tests for services
